### PR TITLE
Store().clear() should not throw an error if the lock file does not exist

### DIFF
--- a/pytest_testrail/store.py
+++ b/pytest_testrail/store.py
@@ -81,4 +81,7 @@ class Store:
         except OSError:
             pass
 
-        os.remove(self.lock_path)
+        try:
+            os.remove(self.lock_path)
+        except OSError:
+            pass

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -27,3 +27,5 @@ def test_store_no_file(request):
     store = Store(request.config)
 
     store.clear()
+    # Clear twice to ensure the files don't exist.
+    store.clear()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -15,3 +15,15 @@ def test_store_set_value_error(request):
 
     with pytest.raises(ValueError):
         store.set_value('cherry', 22002220)
+
+
+def test_store_no_file(request):
+    """Scenario: Tried to clear the store but no store file exists
+
+    When Store().clear() is called
+    And no operation has created the store file
+    Then nothing happens
+    """
+    store = Store(request.config)
+
+    store.clear()


### PR DESCRIPTION
- Cleanup Store() docstrings